### PR TITLE
Describe recommended interval representation: 0-based half-open / interbase

### DIFF
--- a/pages/_formats/genome-coordinates.md
+++ b/pages/_formats/genome-coordinates.md
@@ -24,12 +24,7 @@ Similarly, represent positions in APIs using 0‑based coordinates.
 
 Consider a subsequence `GAGTGC` of a larger sequence of bases (which might be a reference chromosome, for example):
 
-```
-    GAGTGC
-GGTGGAGTGCGCCGCCATGG
-         11111111112
-12345678901234567890
-```
+![Sequence data with 1-based coordinates](1-based.svg)
 
 When a human is working with this subsequence, or it is being discussed amongst humans, we might refer to it as spanning coordinates 5--10 on the larger sequence.
 Formally, this is 1-based inclusive/closed-at-both-ends reckoning, and it's natural and convenient for humans as it's what we're used to.
@@ -37,23 +32,13 @@ Formally, this is 1-based inclusive/closed-at-both-ends reckoning, and it's natu
 However this is not the best coordinate representation for doing arithmetic with.
 Interval arithmetic and the representation of edge cases are more straightforward and unambiguous using a 0-based half-open representation:
 
-```
-    GAGTGC
-GGTGGAGTGCGCCGCCATCG
-          11111111112
-012345678901234567890
-```
+![Sequence data with 0-based coordinates](0-based.svg)
 
 In this representation we would write the subsequence as spanning the interval \[4,10) --- i.e., starting at (zero-based) position 4, and continuing up to but not including position 10.
 
 An alternative and equivalent way to look at this is to think of the bases as lying _between_ the coordinate positions:
 
-```
-         G A G T G C
- G G T G G A G T G C G C C G C C A T G G
-                    1 1 1 1 1 1 1 1 1 1 2
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
-```
+![Sequence data with interbase coordinates](interbase.svg)
 
 In these **interbase** coordinates, we would say the subsequence lies between positions 4 and 10.
 
@@ -73,14 +58,7 @@ Further advantages include in particular the unambiguous representation of indel
 The interbase interpretation is a particularly effective way of thinking about insertions and other events that occur between bases.
 Consider again this twenty base reference sequence:
 
-```
-AAA                             TTT     GGG
-\ /                       T     \ /     \ /
- V       |-----------|    |      V       V
-  G G T G G A G T G C G C C G C C A T G G
-                     1 1 1 1 1 1 1 1 1 1 2
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
-```
+![Insertions and deletions](indels.svg)
 
 These insertions are unambiguously at between-bases positions 0, 16, and 20.
 By interpreting the position as between the bases, 16 clearly indicates that the `TTT` is inserted between `C` and `A`, and the `AAA` and `GGG` are clearly inserted at the start or end of the sequence.
@@ -106,11 +84,7 @@ Using fully-inclusive human-readable notation leads to inferior representations 
 Consider some feature lying on an exon, whose location is represented as \[fs,fe) relative to the start of the exon.
 In turn, the exon is located at coordinates \[es,ee) on a reference chromosome:
 
-```
-          [fs      ]fe
-     [es                  ]ee
------------------------------------ [DIAGRAM FIXME]
-```
+![Feature nested on an exon](nested.svg)
 
 With 0-based coordinates, calculating the feature's location on the chromosome is simple: \[fs+es,fe+es).
 

--- a/pages/_formats/genome-coordinates.md
+++ b/pages/_formats/genome-coordinates.md
@@ -1,8 +1,11 @@
 ---
 title: "Genome Coordinates"
 layout: default
-date: 2018-12-21
-author: "@mbaudis"
+date: 2019-01-08
+author: "@jmarshall"
+description: >
+  Recommendations to use 0-based positions and 0-based half-open intervals
+  when representing genome coordinates and regions in APIs.
 excerpt_separator: <!--more-->
 category:
   - formats
@@ -12,10 +15,121 @@ tags:
 
 ## {{ page.title }}
 
-This documentation needs to be edited, to represent the GA4GH convention of using "... 0-based, half open coordinates [.,.) ".
+### Recommendation
 
-For now please see 
+Represent intervals in APIs using **0-based half-open** coordinates, also referred to as **interbase** representation.
+Similarly, represent positions in APIs using 0‑based coordinates.
+
+### Summary
+
+Consider a subsequence `GAGTGC` of a larger sequence of bases (which might be a reference chromosome, for example):
+
+```
+    GAGTGC
+GGTGGAGTGCGCCGCCATGG
+         11111111112
+12345678901234567890
+```
+
+When a human is working with this subsequence, or it is being discussed amongst humans, we might refer to it as spanning coordinates 5--10 on the larger sequence.
+Formally, this is 1-based inclusive/closed-at-both-ends reckoning, and it's natural and convenient for humans as it's what we're used to.
+
+However this is not the best coordinate representation for doing arithmetic with.
+Interval arithmetic and the representation of edge cases are more straightforward and unambiguous using a 0-based half-open representation:
+
+```
+    GAGTGC
+GGTGGAGTGCGCCGCCATCG
+          11111111112
+012345678901234567890
+```
+
+In this representation we would write the subsequence as spanning the interval \[4,10) --- i.e., starting at (zero-based) position 4, and continuing up to but not including position 10.
+
+An alternative and equivalent way to look at this is to think of the bases as lying _between_ the coordinate positions:
+
+```
+         G A G T G C
+ G G T G G A G T G C G C C G C C A T G G
+                    1 1 1 1 1 1 1 1 1 1 2
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
+```
+
+In these **interbase** coordinates, we would say the subsequence lies between positions 4 and 10.
+
+Similarly, we would describe the `T` within this subsequence as spanning the interval \[7,8) or lying between positions 7 and 8.
+When using a single coordinate to refer to positions rather than intervals, using a 0-based coordinate is consistent with this recommended interval representation; thus this `T` is at position 7.
+
+### Details
+
+The length of this `GAGTGC` subsequence can be calculated from the recommended representation as 10 -- 4 = 6.
+Starting from the human-readable representation the calculation is slightly more complicated: 10 -- 5 + 1 = 6.
+Avoiding the need to add or subtract 1 throughout calculations reduces an entire category of programming error and is the most obvious advantage of the recommended representation.
+
+Further advantages include in particular the unambiguous representation of indels (due to the interbase / half-open coordinates) and simpler conversions between relative coordinate systems (due to the zero-based coordinates).
+
+#### Insertions and deletions
+
+The interbase interpretation is a particularly effective way of thinking about insertions and other events that occur between bases.
+Consider again this twenty base reference sequence:
+
+```
+AAA                             TTT     GGG
+\ /                       T     \ /     \ /
+ V       |-----------|    |      V       V
+  G G T G G A G T G C G C C G C C A T G G
+                     1 1 1 1 1 1 1 1 1 1 2
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
+```
+
+These insertions are unambiguously at between-bases positions 0, 16, and 20.
+By interpreting the position as between the bases, 16 clearly indicates that the `TTT` is inserted between `C` and `A`, and the `AAA` and `GGG` are clearly inserted at the start or end of the sequence.
+
+Similarly deletion of the `GAGTGC` sequence would be recorded as a deletion between 4 and 10, and the `C` to `T` substitution shown would be recorded as a substitution between 12 and 13.
+
+By describing the insertion positions as 0-length intervals --- \[16,16) being the empty interval between the `C` and `A` bases, etc --- this becomes a representation that clearly describes the locations of insertions, deletions, and base changes with the coordinates being interpreted in the same way in all cases:
+
+* replace \[0,0) with `AAA`
+* replace \[4,10) with nothing
+* replace \[12,13) with `T`
+* replace \[16,16) with `TTT`
+* replace \[20,20) with `GGG`
+
+and that can also describe complex indels in the same way, e.g., the same `GAGTGC` deletion combined with an insertion in the same place:
+
+* replace \[4,10) with `TCGT`.
+
+Using fully-inclusive human-readable notation leads to inferior representations of these events, as "insert `TTT` at 17" is unclear whether the insertion is between `C-A` or `A-T`, while mentioning both flanking bases as per "insert `TTT` at 16/17" must be interpreted differently from the corresponding deletion notation.
+
+#### Converting between coordinate systems
+
+Consider some feature lying on an exon, whose location is represented as \[fs,fe) relative to the start of the exon.
+In turn, the exon is located at coordinates \[es,ee) on a reference chromosome:
+
+```
+          [fs      ]fe
+     [es                  ]ee
+----------------------------------- [DIAGRAM FIXME]
+```
+
+With 0-based coordinates, calculating the feature's location on the chromosome is simple: \[fs+es,fe+es).
+
+Similarly to finding the length of a subsequence in an inclusive notation, in 1‑based coordinates this calculation would require carefully subtracting 1 as appropriate.
+When strandedness comes into play and the feature's exon-coordinates are perhaps reversed, tracking the appropriate places to add and subtract 1 becomes harder.
+Thus 1-based coordinates are more susceptible to _off-by-one_ programming errors.
+
+### Conclusion
+
+User interfaces will likely continue to use familiar "human-readable" 1-based positions and inclusive interval notation (perhaps with special notation for indels where applicable).
+This is entirely appropriate.
+
+However for internal purposes, where consistent unambiguous notation and ease of arithmetic are paramount, 0-based half-open / interbase notation is the better choice.
+GA4GH APIs facilitate the external communication of internal data representations; thus the same advantages are paramount, and they, in general, use the interval and position representations described here.
+
+### Further Reading
 
 * the [documentation](https://ga4gh-schemas.readthedocs.io/en/latest/schemas/variants.proto.html#protobuf.Variant) of the `Variant` object for the original [_GA4GH schema_](https://github.com/ga4gh/ga4gh-schemas)
-* a [recent discussion](https://github.com/ga4gh-beacon/specification/issues/251) on Github, and the links from there
+and the discussions that led to it:
+[#49](https://github.com/ga4gh/ga4gh-schemas/pull/49#issuecomment-44503976)
+and [#121](https://github.com/ga4gh/ga4gh-schemas/issues/121).
 * a [nice explanation of coordinate systems](https://www.biostars.org/p/84686/) at _Biostars.org_ by Obi Griffith

--- a/pages/_formats/genome-coordinates/0-based.svg
+++ b/pages/_formats/genome-coordinates/0-based.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 40">
+<g transform="translate(0,35)" style="font-family: sans-serif; font-size: 8; text-anchor: middle">
+<path d="M20,-10h400 M20,-12v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5" stroke="grey" />
+<text x="20,40,60,80,100,120,140,160,180,200">0123456789</text>
+<text x="220">10</text>
+<text x="240">11</text>
+<text x="260">12</text>
+<text x="280">13</text>
+<text x="300">14</text>
+<text x="320">15</text>
+<text x="340">16</text>
+<text x="360">17</text>
+<text x="380">18</text>
+<text x="400">19</text>
+<text x="420">20</text>
+</g>
+<g transform="translate(0,4)" style="font-family: Courier, fixed; font-size: 14; text-anchor: middle">
+<rect x="90" y="0" width="120" height="21" stroke="black" fill="silver" />
+<text x="20,40,60,80,100,120,140,160,180,200,220,240,260,280,300,320,340,360,380,400" y="15">GGTGGAGTGCGCCGCCATGG</text>
+</g>
+</svg>

--- a/pages/_formats/genome-coordinates/1-based.svg
+++ b/pages/_formats/genome-coordinates/1-based.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 40">
+<g transform="translate(0,35)" style="font-family: sans-serif; font-size: 8; text-anchor: middle">
+<path d="M20,-10h380 M20,-12v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5 m20,0v5 m20,0v-5" stroke="silver" />
+<text x="20,40,60,80,100,120,140,160,180">123456789</text>
+<text x="200">10</text>
+<text x="220">11</text>
+<text x="240">12</text>
+<text x="260">13</text>
+<text x="280">14</text>
+<text x="300">15</text>
+<text x="320">16</text>
+<text x="340">17</text>
+<text x="360">18</text>
+<text x="380">19</text>
+<text x="400">20</text>
+</g>
+<g transform="translate(0,4)" style="font-family: Courier, fixed; font-size: 14; text-anchor: middle">
+<rect x="90" y="0" width="120" height="21" stroke="black" fill="silver" />
+<text x="20,40,60,80,100,120,140,160,180,200,220,240,260,280,300,320,340,360,380,400" y="15">GGTGGAGTGCGCCGCCATGG</text>
+</g>
+</svg>

--- a/pages/_formats/genome-coordinates/indels.svg
+++ b/pages/_formats/genome-coordinates/indels.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 435 53">
+<defs>
+<g id="ins" style="stroke: #a92420; fill: none">
+  <path d="M-15,-22 c3,15 10,0 15,18 c5,-18 12,-3 15,-18" />
+</g>
+</defs>
+<g transform="translate(0,47)" style="font-family: sans-serif; font-size: 8; text-anchor: middle">
+<path d="M20,-10h400 M20,-14v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7" stroke="grey" />
+<text x="20,40,60,80,100,120,140,160,180,200">0123456789</text>
+<text x="220">10</text>
+<text x="240">11</text>
+<text x="260">12</text>
+<text x="280">13</text>
+<text x="300">14</text>
+<text x="320">15</text>
+<text x="340">16</text>
+<text x="360">17</text>
+<text x="380">18</text>
+<text x="400">19</text>
+<text x="420">20</text>
+</g>
+<g transform="translate(0,33)" style="font-family: Courier, fixed; font-size: 14; text-anchor: middle">
+<text x="30,50,70,90">GGTG</text>
+<text x="110,130,150,170,190,210,270" style="fill: #a92420">GAGTGCC</text>
+<text x="230,250">GC</text>
+<text x="290,310,330,350,370,390,410">GCCATGG</text>
+<path d="M102,-4 h116 M265,1 l10,-10 m0,10 l-10,-10" style="stroke: #a92420" />
+<text x="270" y="-10">T</text>
+<use xlink:href="#ins" x="20"  /><text x="20"  y="-20">AAA</text>
+<use xlink:href="#ins" x="340" /><text x="340" y="-20">TTT</text>
+<use xlink:href="#ins" x="420" /><text x="420" y="-20">GGG</text>
+</g>
+</svg>

--- a/pages/_formats/genome-coordinates/interbase.svg
+++ b/pages/_formats/genome-coordinates/interbase.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 40">
+<g transform="translate(0,35)" style="font-family: sans-serif; font-size: 8; text-anchor: middle">
+<path d="M10,-10h400 M10,-14v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7 m20,0v-7 m20,0v7" stroke="grey" />
+<text x="10,30,50,70,90,110,130,150,170,190">0123456789</text>
+<text x="210">10</text>
+<text x="230">11</text>
+<text x="250">12</text>
+<text x="270">13</text>
+<text x="290">14</text>
+<text x="310">15</text>
+<text x="330">16</text>
+<text x="350">17</text>
+<text x="370">18</text>
+<text x="390">19</text>
+<text x="410">20</text>
+</g>
+<g transform="translate(0,4)" style="font-family: Courier, fixed; font-size: 14; text-anchor: middle">
+<rect x="90" y="0" width="120" height="21" stroke="black" fill="silver" />
+<text x="20,40,60,80,100,120,140,160,180,200,220,240,260,280,300,320,340,360,380,400" y="15">GGTGGAGTGCGCCGCCATGG</text>
+</g>
+</svg>

--- a/pages/_formats/genome-coordinates/nested.svg
+++ b/pages/_formats/genome-coordinates/nested.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 60">
+<path transform="translate(0,47)" d="M10,0h410 M20,-2v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4" stroke="silver" />
+<rect x="90" y="26" width="220" height="21" stroke="black" fill="silver" />
+<path transform="translate(90,26)" d="M0,-2v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4 m10,0v-4 m10,0v4" stroke="grey" />
+<rect x="150" y="5" width="60" height="21" stroke="black" fill="silver" />
+<g style="font-family: sans-serif; font-size: 10; text-anchor: middle">
+<text x="152" y="37">fs</text>
+<text x="212" y="37">fe</text>
+<text x="93" y="58">es</text>
+<text x="313" y="58">ee</text>
+</g>
+<g style="font-family: sans-serif; font-style: italic; font-size: 8; text-anchor: left">
+<text x="152" y="18">Feature</text>
+<text x="93" y="39">Exon</text>
+</g>
+</svg>


### PR DESCRIPTION
Expand the description of the proposed recommendation of using 0-based half-open aka interbase coordinates for intervals (and correspondingly 0-based positions).

Previous discussions of interval representations have gone round and round in circles attempting to convince the recalcitrant that any particular coordinate system might have actual advantages that are not shared by other coordinate systems. (cf ga4gh/ga4gh-schemas#121.)

So this PR attempts to motivate the (to be) recommended representation by discussing its advantages: uniform representation of insertions/deletions/substitutions; ease of calculations, notably converting between nested coordinate systems.

(There is certainly scope for improving the diagrams, especially the last one!)