### PR TITLE
"Core" for only blocks in SC approved standards

### DIFF
--- a/pages/_general/schemablocks-status-levels.md
+++ b/pages/_general/schemablocks-status-levels.md
@@ -49,4 +49,4 @@ The current status level of thiose recommendations is "proposed".
 * `core`
 	- a schema block with recommended use
 	- stable through minor version changes
-	- has to be used in at least 2 steering committee approved GA4GH standards
+	- has to be used in at least 2 GA4GH Steering Committee approved GA4GH standards

--- a/pages/_general/schemablocks-status-levels.md
+++ b/pages/_general/schemablocks-status-levels.md
@@ -49,4 +49,4 @@ The current status level of thiose recommendations is "proposed".
 * `core`
 	- a schema block with recommended use
 	- stable through minor version changes
-	- has to be used in at least 2 approved / under review GA4GH products
+	- has to be used in at least 2 steering committee approved GA4GH standards

--- a/pages/_general/schemablocks-status-levels.md
+++ b/pages/_general/schemablocks-status-levels.md
@@ -49,4 +49,4 @@ The current status level of thiose recommendations is "proposed".
 * `core`
 	- a schema block with recommended use
 	- stable through minor version changes
-	- has to be used in at least 2 GA4GH Steering Committee approved GA4GH standards
+	- has to be used in at least 2 standards/products approved by the GA4GH Steering Committee 


### PR DESCRIPTION
I believe the label of "core" should only be used when the deliverables they are in have been officially approved by SC.  It was already written as being in 2 products and I did not change that.  Whether you want to make it 1 or two is up to the team.